### PR TITLE
ファイルをダウンロードするdownloadサブコマンドの追加

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -57,7 +57,16 @@ func downloadDo(id, name string) error {
 
 	res, err := req.Do(ctx)
 	if err != nil {
-		return err
+		if res == nil {
+			return err
+		}
+
+		content, rErr := ioutil.ReadAll(res)
+		if rErr != nil {
+			return rErr
+		}
+
+		return fmt.Errorf("%v\n%s", err, string(content))
 	}
 
 	content, err := ioutil.ReadAll(res)

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -43,7 +43,11 @@ func init() {
 
 func downloadDo(id, name string) error {
 	if len(id) == 0 {
-		return fmt.Errorf("Idをに空できません")
+		return fmt.Errorf("idをに空できません")
+	}
+
+	if len(name) == 0 {
+		return fmt.Errorf("出力先のファイル名を空にはできません")
 	}
 
 	req, err := request.New(cfg, http.MethodGet, request.Download)
@@ -51,22 +55,13 @@ func downloadDo(id, name string) error {
 		return err
 	}
 
-	if err := req.WithLogger(logger).SetLastPath(id).Build(); err != nil {
+	if err := req.WithLogger(logger).AddPath(id).Build(); err != nil {
 		return err
 	}
 
 	res, err := req.Do(ctx)
 	if err != nil {
-		if res == nil {
-			return err
-		}
-
-		content, rErr := ioutil.ReadAll(res)
-		if rErr != nil {
-			return rErr
-		}
-
-		return fmt.Errorf("%v\n%s", err, string(content))
+		return err
 	}
 
 	content, err := ioutil.ReadAll(res)

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/xztaityozx/dbasectl/request"
+)
+
+var downloadCmd = &cobra.Command{
+	Use:     "download",
+	Short:   "ファイルをダウンロードします",
+	Long:    `IDを指定してDocBaseからファイルをダウンロードします。`,
+	Example: "dbasectl download [Id]",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("Idは1つ指定してください")
+		}
+
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		name, _ := cmd.Flags().GetString("out")
+
+		if len(name) == 0 {
+			name = id
+		}
+
+		if err := downloadDo(id, name); err != nil {
+			logrus.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(downloadCmd)
+	downloadCmd.Flags().StringP("out", "o", "", "出力ファイル名です。指定しない場合idが使われます。")
+}
+
+func downloadDo(id, name string) error {
+	if len(id) == 0 {
+		return fmt.Errorf("Idをに空できません")
+	}
+
+	req, err := request.New(cfg, http.MethodGet, request.Download)
+	if err != nil {
+		return err
+	}
+
+	if err := req.WithLogger(logger).SetLastPath(id).Build(); err != nil {
+		return err
+	}
+
+	res, err := req.Do(ctx)
+	if err != nil {
+		return err
+	}
+
+	content, err := ioutil.ReadAll(res)
+
+	return ioutil.WriteFile(name, content, 0644)
+}

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/xztaityozx/dbasectl/config"
+	"testing"
+)
+
+func Test_downloadDo(t *testing.T) {
+	as := assert.New(t)
+	t.Run("Idを空にしたとき", func(t *testing.T) {
+		as.Error(downloadDo("", ""), "エラーが返されるべき")
+	})
+
+	t.Run("ファイル名を空にしたとき", func(t *testing.T) {
+		as.Error(downloadDo("id", ""), "エラーが返されるべき")
+	})
+
+	t.Run("コンフィグが正しくないとき", func(t *testing.T) {
+		cfg = config.Config{}
+		as.Error(downloadDo("id", "name"), "エラーが返されるべき")
+	})
+}

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -20,7 +20,7 @@ var uploadCmd = &cobra.Command{
 	Long:    `ファイルや画像をDocBaseにアップロードします。レスポンスとして、idやpath、markdownへの埋め込み情報などが記述されたJSONをSTDOUTに出力します`,
 	Example: "dbasectl upload /path/to/image.png",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := do(args...); err != nil {
+		if err := uploadDo(args...); err != nil {
 			logrus.Fatal(err)
 		}
 	},
@@ -35,7 +35,7 @@ func init() {
 	rootCmd.AddCommand(uploadCmd)
 }
 
-func do(files ...string) error {
+func uploadDo(files ...string) error {
 	dic := map[string]string{}
 
 	for _, file := range files {

--- a/cmd/upload_test.go
+++ b/cmd/upload_test.go
@@ -18,7 +18,7 @@ func Test_Do(t *testing.T) {
 	as.Nil(os.MkdirAll(baseDir, 0755))
 
 	t.Run("ディレクトリはUploadできない", func(t *testing.T) {
-		as.Error(do(baseDir))
+		as.Error(uploadDo(baseDir))
 	})
 
 	t.Run("スペシャルファイルはUploadできない", func(t *testing.T) {
@@ -26,17 +26,17 @@ func Test_Do(t *testing.T) {
 			t.Skip()
 		}
 
-		as.Error(do("/dev/null"), "/dev/nullはUpできない")
-		as.Error(do("/dev/nu??"), "Globも展開できる")
+		as.Error(uploadDo("/dev/null"), "/dev/nullはUpできない")
+		as.Error(uploadDo("/dev/nu??"), "Globも展開できる")
 	})
 
 	t.Run("存在しないファイルはUploadできない", func(t *testing.T) {
 		p := filepath.Join(baseDir, "none")
-		as.Error(do(p))
+		as.Error(uploadDo(p))
 	})
 
 	t.Run("指定が0個のときはUploadできない", func(t *testing.T) {
-		as.Error(do())
+		as.Error(uploadDo())
 	})
 
 	t.Run("configが不足しててUploadできない", func(t *testing.T) {
@@ -44,8 +44,8 @@ func Test_Do(t *testing.T) {
 		as.Nil(ioutil.WriteFile(p, []byte("それ"), 0644))
 
 		cfg = config.Config{}
-		as.Error(do(p))
-		as.Error(do(filepath.Join(baseDir, "fi??")), "Globでも良い")
+		as.Error(uploadDo(p))
+		as.Error(uploadDo(filepath.Join(baseDir, "fi??")), "Globでも良い")
 		_ = os.Remove(p)
 	})
 

--- a/request/request.go
+++ b/request/request.go
@@ -128,6 +128,10 @@ func (r *Request) Do(ctx context.Context) (responseBody io.ReadCloser, err error
 		return nil, fmt.Errorf("response is nil")
 	}
 
+	if res.StatusCode != 200 {
+		return res.Body, fmt.Errorf("APIがステータスコード %d を返しました", res.StatusCode)
+	}
+
 	return res.Body, nil
 }
 

--- a/request/request.go
+++ b/request/request.go
@@ -16,7 +16,8 @@ import (
 type EndPoint string
 
 const (
-	Upload EndPoint = "attachments"
+	Upload   EndPoint = "attachments"
+	Download EndPoint = "attachments"
 )
 
 type Request struct {
@@ -95,7 +96,14 @@ func (r *Request) Build() error {
 		}
 	}
 
+	logrus.Info(r.req.URL.String())
+
 	return err
+}
+
+func (r *Request) SetLastPath(item string) *Request {
+	r.url += "/" + item
+	return r
 }
 
 // Do は DocBaseのAPIにアクセスして、そのレスポンスボディを返す
@@ -137,6 +145,7 @@ func (r *Request) warn(args ...interface{}) {
 
 var allowedDictionary = map[string][]EndPoint{
 	http.MethodPost: {Upload},
+	http.MethodGet:  {Download},
 }
 
 func isAllowedEndPoint(method string, ep EndPoint) bool {

--- a/request/request.go
+++ b/request/request.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"path"
 	"regexp"
 	"time"
 
@@ -23,7 +25,7 @@ const (
 type Request struct {
 	cfg    config.Config
 	req    *http.Request
-	url    string
+	url    *url.URL
 	logger *logrus.Logger
 	body   io.Reader
 	method string
@@ -43,9 +45,12 @@ func New(cfg config.Config, method string, ep EndPoint) (Request, error) {
 		return Request{}, fmt.Errorf("%s method is not allowed to %s endpoint", method, ep)
 	}
 
-	url := fmt.Sprintf("https://api.docbase.io/teams/%s/%s", cfg.Name, ep)
+	u, err := url.Parse(fmt.Sprintf("https://api.docbase.io/teams/%s/%s", cfg.Name, ep))
+	if err != nil {
+		return Request{}, err
+	}
 
-	return Request{cfg: cfg, req: nil, url: url, logger: nil, method: method}, nil
+	return Request{cfg: cfg, req: nil, url: u, logger: nil, method: method}, nil
 }
 
 // WithLogger は logrus.Logger をセットした Request を返す
@@ -75,16 +80,16 @@ func (r *Request) Build() error {
 
 	// セットされているURLが正しいっぽいかどうか
 	// 少なくとも以下の正規表現を満たしていないといけない
-	if ok, err := regexp.MatchString("https://api.docbase.io/teams/.+/.+", r.url); err != nil {
+	if ok, err := regexp.MatchString("https://api.docbase.io/teams/.+/.+", r.url.String()); err != nil {
 		return err
 	} else if !ok {
 		return fmt.Errorf("invalid URL: %s", r.url)
 	} else {
-		r.info("url: ", r.url)
+		r.info("url: ", r.url.String())
 	}
 
 	var err error
-	r.req, err = http.NewRequest(r.method, r.url, r.body)
+	r.req, err = http.NewRequest(r.method, r.url.String(), r.body)
 	r.req.Header.Set("X-DocBaseToken", r.cfg.Token)
 
 	// POST系はJSONを投げるので、Content-Typeを指定しておく
@@ -96,13 +101,12 @@ func (r *Request) Build() error {
 		}
 	}
 
-	logrus.Info(r.req.URL.String())
-
 	return err
 }
 
-func (r *Request) SetLastPath(item string) *Request {
-	r.url += "/" + item
+// AddPath はURLのにパスを追加する
+func (r *Request) AddPath(item string) *Request {
+	r.url.Path = path.Join(r.url.Path, item)
 	return r
 }
 

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -124,6 +124,8 @@ func TestRequest_Build(t *testing.T) {
 				as.Equal(cfg.Token, r.req.Header.Get("X-DocBaseToken"), "Tokenが正しくセットされている")
 				as.Equal(fmt.Sprintf("https://api.docbase.io/teams/%s/%s", cfg.Name, ep), r.req.URL.String(), "URLが正しい")
 
+				as.Equal(cfg.Token, r.req.Header.Get("X-DocBaseToken"))
+
 				if method == http.MethodPost {
 					as.Equal("application/json", r.req.Header.Get("Content-Type"), "POSTではJSONを投げる")
 				}
@@ -133,7 +135,6 @@ func TestRequest_Build(t *testing.T) {
 }
 
 func TestRequest_AddPath(t *testing.T) {
-
 	u, _ := url.Parse("https://example.com")
 	r := Request{url: u}
 	r.AddPath("item")

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -49,10 +50,11 @@ func TestNew(t *testing.T) {
 				req, err := New(cfg, method, ep)
 
 				as.Nil(err)
+				u, _ := url.Parse(fmt.Sprintf("https://api.docbase.io/teams/%s/%s", cfg.Name, ep))
 				as.Equal(Request{
 					cfg:    cfg,
 					req:    nil,
-					url:    fmt.Sprintf("https://api.docbase.io/teams/%s/%s", cfg.Name, ep),
+					url:    u,
 					logger: nil,
 					method: method,
 				}, req, "Requestが返される")
@@ -99,7 +101,7 @@ func TestRequest_Build(t *testing.T) {
 	})
 
 	t.Run("URLが正しくないとき", func(t *testing.T) {
-		r := Request{method: http.MethodPost, url: "invalid"}
+		r := Request{method: http.MethodPost, url: &url.URL{Path: "invalid"}}
 		as.Error(r.Build(), "エラーが返されるべき")
 	})
 
@@ -128,4 +130,13 @@ func TestRequest_Build(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestRequest_AddPath(t *testing.T) {
+
+	u, _ := url.Parse("https://example.com")
+	r := Request{url: u}
+	r.AddPath("item")
+
+	assert.Equal(t, "https://example.com/item", r.url.String())
 }

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -3,12 +3,13 @@ package request
 import (
 	"bytes"
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	"github.com/xztaityozx/dbasectl/config"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/xztaityozx/dbasectl/config"
 )
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
タイトルどおり。

```
dbasectl download [id]
```

`id`は必須。1つのみ指定可能。`id`はuploadのレスポンスにあるもののみ
